### PR TITLE
Fix PTHotKey.framework 10.12 issues, deprecated enums

### DIFF
--- a/PTHotKey/PTHotKeyCenter.m
+++ b/PTHotKey/PTHotKeyCenter.m
@@ -212,7 +212,7 @@ static PTHotKeyCenter *_sharedHotKeyCenter = nil;
 	short subType;
 	EventHotKeyRef carbonHotKey;
 
-	if( [event type] == NSSystemDefined )
+	if( [event type] == NSEventTypeSystemDefined )
 	{
 		subType = [event subtype];
 

--- a/PTHotKey/PTKeyCombo.m
+++ b/PTHotKey/PTKeyCombo.m
@@ -49,7 +49,7 @@
             case kVK_F18:
             case kVK_F19:
             case kVK_F20:
-                mModifiers = modifiers | NSFunctionKeyMask;
+              mModifiers = modifiers | NSEventModifierFlagFunction;
                 break;
             default:
                 mModifiers = modifiers;
@@ -234,10 +234,10 @@
 
 	static NSUInteger modToChar[4][2] =
 	{
-		{ cmdKey, 		NSCommandKeyMask },
-		{ optionKey,	NSAlternateKeyMask },
-		{ controlKey,	NSControlKeyMask },
-		{ shiftKey,		NSShiftKeyMask }
+      { cmdKey, 		NSEventModifierFlagCommand },
+      { optionKey,	NSEventModifierFlagOption },
+      { controlKey,	NSEventModifierFlagControl },
+      { shiftKey,		NSEventModifierFlagShift }
 	};
 
     NSUInteger i, ret = 0;


### PR DESCRIPTION
Snagit did this for ShortcutRecorder.framework when they dropped 10.11 in #9 but we use PTHotKey.framework