### PR TITLE
Fixes for Xcode 10.2

### DIFF
--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -450,6 +450,10 @@
 				German,
 				infoplist.strings,
 				zh,
+				de,
+				en,
+				fr,
+				ja,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* ShortcutRecorder */;
 			projectDirPath = "";

--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -441,19 +441,16 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "ShortcutRecorder" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				infoplist.strings,
 				zh,
 				de,
 				en,
 				fr,
 				ja,
+				Base,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* ShortcutRecorder */;
 			projectDirPath = "";


### PR DESCRIPTION
After opening in Xcode 10.2, it adds some languages to the pbxproj
Migrate from long names `English` to language codes `en`