### PR TITLE
Shorten Unassigned Shortcut String

### DIFF
--- a/SRRecorderControl.m
+++ b/SRRecorderControl.m
@@ -149,7 +149,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
                                            forOrientation:NSLayoutConstraintOrientationVertical];
         }
 
-       NSString* sgwaesf = NSLocalizedStringFromTableInBundle(@"Click to record shortcut",
+       NSString* sgwaesf = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
                                                               @"ShortcutRecorder",
                                                               [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                                nil);
@@ -281,7 +281,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
         self.objectValue = anObjectValue;
 
     [self updateTrackingAreas];
-   [self setToolTip:NSLocalizedStringFromTableInBundle(@"Click to record shortcut",
+   [self setToolTip:NSLocalizedStringFromTableInBundle(@"Add Shortcut",
                                                        @"ShortcutRecorder",
                                                        [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                        nil)];
@@ -403,7 +403,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
        label = self.stringValue;
        
        if (![label length])
-          label = NSLocalizedStringFromTableInBundle(@"Click to record shortcut",
+          label = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
                                                      @"ShortcutRecorder",
                                                      [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                      nil);
@@ -432,7 +432,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
         label = self.accessibilityStringValue;
 
         if (![label length])
-           label = NSLocalizedStringFromTableInBundle(@"Click to record shortcut",
+           label = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
                                                       @"ShortcutRecorder",
                                                       [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                       nil);
@@ -985,7 +985,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
 
 - (NSSize)intrinsicContentSize
 {
-   return NSMakeSize(NSWidth([self rectForLabel:NSLocalizedStringFromTableInBundle(@"Click to record shortcut",
+   return NSMakeSize(NSWidth([self rectForLabel:NSLocalizedStringFromTableInBundle(@"Add Shortcut",
                                                                                    @"ShortcutRecorder",
                                                                                    [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                                                    nil) withAttributes:self.normalLabelAttributes]) + _SRRecorderControlShapeXRadius + _SRRecorderControlShapeXRadius,

--- a/SRRecorderControl.m
+++ b/SRRecorderControl.m
@@ -149,7 +149,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
                                            forOrientation:NSLayoutConstraintOrientationVertical];
         }
 
-       NSString* sgwaesf = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
+       NSString* sgwaesf = NSLocalizedStringFromTableInBundle(@"+ Shortcut",
                                                               @"ShortcutRecorder",
                                                               [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                                nil);
@@ -281,7 +281,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
         self.objectValue = anObjectValue;
 
     [self updateTrackingAreas];
-   [self setToolTip:NSLocalizedStringFromTableInBundle(@"Add Shortcut",
+   [self setToolTip:NSLocalizedStringFromTableInBundle(@"+ Shortcut",
                                                        @"ShortcutRecorder",
                                                        [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                        nil)];
@@ -403,7 +403,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
        label = self.stringValue;
        
        if (![label length])
-          label = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
+          label = NSLocalizedStringFromTableInBundle(@"+ Shortcut",
                                                      @"ShortcutRecorder",
                                                      [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                      nil);
@@ -432,7 +432,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
         label = self.accessibilityStringValue;
 
         if (![label length])
-           label = NSLocalizedStringFromTableInBundle(@"Add Shortcut",
+           label = NSLocalizedStringFromTableInBundle(@"+ Shortcut",
                                                       @"ShortcutRecorder",
                                                       [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                       nil);
@@ -985,7 +985,7 @@ static NSValueTransformer *_SRValueTransformerFromBindingOptions(NSDictionary *a
 
 - (NSSize)intrinsicContentSize
 {
-   return NSMakeSize(NSWidth([self rectForLabel:NSLocalizedStringFromTableInBundle(@"Add Shortcut",
+   return NSMakeSize(NSWidth([self rectForLabel:NSLocalizedStringFromTableInBundle(@"+ Shortcut",
                                                                                    @"ShortcutRecorder",
                                                                                    [NSBundle bundleWithIdentifier:SRBundleIdentifier],
                                                                                    nil) withAttributes:self.normalLabelAttributes]) + _SRRecorderControlShapeXRadius + _SRRecorderControlShapeXRadius,

--- a/en.lproj/ShortcutRecorder.strings
+++ b/en.lproj/ShortcutRecorder.strings
@@ -1,7 +1,7 @@
-﻿"Space" = "Space";
+"Space" = "Space";
 "Use old shortcut" = "Use previous shortcut";
 "Type shortcut" = "Type shortcut";
-"Click to record shortcut" = "Add Shortcut";
+"Add Shortcut" = "+ Shortcut";
 "Pad %@" = "Pad %@";
 "The key combination “%@” can't be used!" = "The key combination “%@” can't be used!";
 "The key combination “%@” can't be used because %@." = "The key combination “%@” can't be used because %@.";

--- a/en.lproj/ShortcutRecorder.strings
+++ b/en.lproj/ShortcutRecorder.strings
@@ -1,7 +1,7 @@
 "Space" = "Space";
 "Use old shortcut" = "Use previous shortcut";
 "Type shortcut" = "Type shortcut";
-"Add Shortcut" = "+ Shortcut";
+"+ Shortcut" = "+ Shortcut";
 "Pad %@" = "Pad %@";
 "The key combination “%@” can't be used!" = "The key combination “%@” can't be used!";
 "The key combination “%@” can't be used because %@." = "The key combination “%@” can't be used because %@.";


### PR DESCRIPTION
Addresses localization issues found in https://github.com/TechSmith/Camtasia-Mac/issues/5887 specifically for the button titles in Shortcut Manager for unassigned shortcuts.

Current localization workflow sends the wrong part of the localizedstring table to Rubric, so an extra long string is being translated. This PR encourages translation of the shorter string instead (in the short term) and moves toward translating an even shorter string (in the long term, once workflow issues are resolved). In tandem with another PR to increase the size of the button in the CMac UI, this should ultimately allow other languages to fit in the button title without truncation.