### PR TITLE
Attempt to fix string values with non-english keyboards.

### DIFF
--- a/SRKeyCodeTransformer.m
+++ b/SRKeyCodeTransformer.m
@@ -281,7 +281,7 @@ FOUNDATION_STATIC_INLINE NSString* _SRUnicharToString(unichar aChar)
 
     if (self.usesASCIICapableKeyboardInputSource)
     {
-        TISInputSourceRef tisSource = TISCopyCurrentASCIICapableKeyboardInputSource();
+        TISInputSourceRef tisSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource();
 
         if (!tisSource)
             return @"";


### PR DESCRIPTION
TLDR Use TISCopyCurrentASCIICapableKeyboardLayoutInputSource instead of TISCopyCurrentASCIICapableKeyboardInputSource

This fixes the issues with shortcuts not appearing correctly in Japanese.  I am not sure what the difference is but:
   1.  We were using TISCopyCurrentASCIICapableKeyboardLayoutInputSource elsewhere in our code for the recorder shortcuts and that has been working.
   1.  MASSShortcut uses TISCopyCurrentASCIICapableKeyboardLayoutInputSource https://github.com/shpakovski/MASShortcut/issues/60