### PR TITLE
Turn off 'Active Arch Only' for Debug builds

### DIFF
--- a/ShortcutRecorder.xcodeproj/project.pbxproj
+++ b/ShortcutRecorder.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 				GCC_PREFIX_HEADER = ShortcutRecorder_Prefix.pch;
 				INFOPLIST_FILE = "ShortcutRecorder-Info.plist";
 				INSTALL_PATH = "@rpath";
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kulakov.ShortcutRecorder;
 				PRODUCT_NAME = ShortcutRecorder;
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
Turn off the "Active Archiecture Only" setting for debug builds. This was needed at one point for arm builds, but may not be needed any longer