### PR TITLE
Fix error about default property (assign) not being appropriate

### DIFF
--- a/SRRecorderControl.h
+++ b/SRRecorderControl.h
@@ -142,7 +142,7 @@ extern NSString *const SRShortcutCharactersIgnoringModifiers;
 
 @property (nonatomic, copy) NSString* placeholderText;
 
-@property NSNumber* cornerRadius;
+@property (nonatomic, copy) NSNumber* cornerRadius;
 
 @property BOOL borderlessButton;
 


### PR DESCRIPTION
Showing Recent Errors Only
> ShortcutRecorder/SRRecorderControl.h:145:1: No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed
ShortcutRecorder/SRRecorderControl.h:145:1: Default property attribute 'assign' not appropriate for object